### PR TITLE
Fix transient

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -51,7 +51,7 @@ function _auto_notify_message() {
 
     if [[ "$platform" == "Linux" ]]; then
         local urgency="normal"
-        local transient="--hint int:transient:1"
+        local transient="--hint=int:transient:1"
         if [[ "$exit_code" != "0" ]]; then
             urgency="critical"
             transient=""

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -51,7 +51,7 @@ function _auto_notify_message() {
 
     if [[ "$platform" == "Linux" ]]; then
         local urgency="normal"
-        local transient="--transient"
+        local transient="--hint int:transient:1"
         if [[ "$exit_code" != "0" ]]; then
             urgency="critical"
             transient=""


### PR DESCRIPTION
Uses the older syntax of `--hint=int:transient:1` instead of the newer opetion `--transient` (available since notify-send 0.7.11).